### PR TITLE
Extend configurable HYPRE solver combinations

### DIFF
--- a/.github/workflows/runs.yml
+++ b/.github/workflows/runs.yml
@@ -26,4 +26,5 @@ jobs:
         export LD_LIBRARY_PATH="${HOME}/hypre/lib:${LD_LIBRARY_PATH}"
         cd tests/lid_driven_cavity && sh testit.sh && cd -
         cd tests/differentially_heated_cavity && sh testit.sh && cd -
+        cd tests/hypre_solver_options && sh testit.sh && cd -
         python -m unittest tests.snac_grid_generator.test_core

--- a/docs/INFO_INPUT.md
+++ b/docs/INFO_INPUT.md
@@ -35,6 +35,11 @@ scalf(:) = 0.
 
 &hypre
 hypre_solver_i = 2, hypre_tol = 1.e-4, hypre_maxiter = 50
+hypre_fft_zero_mode_solver_i = 0
+hypre_precond_i = 1, hypre_precond_maxiter = 10
+hypre_gmres_k_dim = 0
+hypre_pfmg_relax_type = -1
+hypre_pfmg_num_pre_relax = 1, hypre_pfmg_num_post_relax = 1
 /
 ```
 
@@ -54,7 +59,27 @@ hypre_solver_i = 2, hypre_tol = 1.e-4, hypre_maxiter = 50
 
 When SNaC is compiled with `BOUSSINESQ_BUOYANCY=1` in `build.conf` or on the `make` command line, the first scalar is active and contributes the Boussinesq acceleration `-gacc(:)*beta*s`. Without that CPP macro, no buoyancy source is compiled in.
 
-The optional `&hypre` namelist controls the iterative Poisson solver. `hypre_solver_i` selects `1: SMG`, `2: PFMG`, `3: GMRES`, or `4: BiCGSTAB`.
+The optional `&hypre` namelist controls the iterative Poisson/Helmholtz solver:
+
+* `hypre_solver_i` selects `1: SMG`, `2: PFMG`, `3: GMRES`, `4: BiCGSTAB`, or `5: FlexGMRES`.
+* Krylov solvers (`3`--`5`) use the preconditioner selected by `hypre_precond_i`: `0: SMG`, `1: PFMG`, or `9: none`. `hypre_precond_maxiter` sets the number of preconditioner cycles per outer iteration.
+* `hypre_gmres_k_dim` sets the restart dimension for GMRES and FlexGMRES. A value of `0` retains the HYPRE default.
+* `hypre_pfmg_relax_type` selects PFMG relaxation type `0`--`3`. Its default, `-1`, retains SNaC's automatic choice: weighted Jacobi for a nonsymmetric matrix and symmetric red/black Gauss--Seidel when symmetric storage is available. `hypre_pfmg_num_pre_relax` and `hypre_pfmg_num_post_relax` set the corresponding sweep counts. These PFMG controls apply both to stand-alone PFMG and to PFMG used as a Krylov preconditioner.
+* With an FFT-enabled, nonsliced-pencil build, `hypre_fft_zero_mode_solver_i` may override the solver used for the pressure system whose local Fourier eigenvalue is zero. Its default, `0`, uses `hypre_solver_i` for every mode. The eigenvalue check also works when the Fourier modes are distributed by the slab path.
+
+For example, the following selects the investigated FlexGMRES(20)+PFMG(1) configuration with nonsymmetric red/black relaxation, no pre-relaxation, and four post-relaxation sweeps:
+
+```fortran
+&hypre
+hypre_solver_i = 5, hypre_tol = 1.e-4, hypre_maxiter = 2000
+hypre_precond_i = 1, hypre_precond_maxiter = 1
+hypre_gmres_k_dim = 20
+hypre_pfmg_relax_type = 3
+hypre_pfmg_num_pre_relax = 0, hypre_pfmg_num_post_relax = 4
+/
+```
+
+For an FFT-reduced pressure solve that retains stand-alone PFMG on the zero mode and uses BiCGSTAB+PFMG(1) on shifted modes, set `hypre_solver_i = 4` and `hypre_fft_zero_mode_solver_i = 2` with the same PFMG controls.
 
 ## `blocks.nml`
 

--- a/src/dns.nml
+++ b/src/dns.nml
@@ -10,4 +10,9 @@ bforce(1:3) = 0., 0., 0.
 
 &hypre
 hypre_solver_i = 2, hypre_tol = 1.e-4, hypre_maxiter = 50
+hypre_fft_zero_mode_solver_i = 0
+hypre_precond_i = 1, hypre_precond_maxiter = 10
+hypre_gmres_k_dim = 0
+hypre_pfmg_relax_type = -1
+hypre_pfmg_num_pre_relax = 1, hypre_pfmg_num_post_relax = 1
 /

--- a/src/main.f90
+++ b/src/main.f90
@@ -50,14 +50,17 @@ program snac
                                  vol_all,my_block,id_first,nblocks,nrank,  &
                                  is_periodic,l_periodic,                   &
                                  lmax_max,lmin_min,                        &
-                                 hypre_tol,hypre_maxiter,hypre_solver_i
+                                 hypre_tol,hypre_maxiter,hypre_solver_i, &
+                                 hypre_fft_zero_mode_solver_i, &
+                                 hypre_precond_i,hypre_precond_maxiter,hypre_gmres_k_dim, &
+                                 hypre_pfmg_relax_type,hypre_pfmg_num_pre_relax,hypre_pfmg_num_post_relax
   use mod_updt_pressure  , only: updt_pressure
   use mod_rk             , only: rk_mom,rk_scal
   use mod_post           , only: cmpt_wall_forces, updt_wall_forces
   use mod_scal           , only: scalar,initialize_scalars,bulk_forcing_s
   use mod_sanity         , only: test_sanity
   use mod_solver         , only: init_bc_rhs,init_matrix_3d,create_solver,setup_solver, &
-                                 solve_helmholtz,finalize_matrix,hypre_solver
+                                 solve_helmholtz,finalize_matrix,hypre_solver,configure_hypre_options
 #ifdef _IMPDIFF
   use mod_solve_helmholtz, only: solve_impdiff_field
 #endif
@@ -193,6 +196,15 @@ program snac
   ! read parameter file
   !
   call read_input()
+  call configure_hypre_options(hypre_precond_i,hypre_precond_maxiter,hypre_gmres_k_dim, &
+                               hypre_pfmg_relax_type,hypre_pfmg_num_pre_relax,hypre_pfmg_num_post_relax)
+#ifdef _FFT_USE_SLICED_PENCILS
+  if(hypre_fft_zero_mode_solver_i > 0) then
+    if(myid == 0) write(stderr,*) 'WARNING: the FFT zero-mode solver override is unavailable with sliced pencils.'
+    if(myid == 0) write(stderr,*) 'Using hypre_solver_i for every sliced-pencil system.'
+    hypre_fft_zero_mode_solver_i = 0
+  end if
+#endif
   !
   ! check sanity of input file
   !
@@ -759,7 +771,12 @@ end if
   call init_n_3d_matrices(idir,nslices,cbcpre,bcpre,dl,.true.,is_bound,is_centered,lo,periods, &
                           lo_sp,hi_sp,dxc,dxf,dyc,dyf,dzc,dzf,alpha,alpha_bc,lambda_p_a,psolver_fft)
 #endif
+#ifndef _FFT_USE_SLICED_PENCILS
+  call create_n_solvers(npsolvers,hypre_maxiter,hypre_tol,.true.,hypre_solver_i,psolver_fft, &
+                        lambda=lambda_p_a,zero_mode_stype=hypre_fft_zero_mode_solver_i)
+#else
   call create_n_solvers(npsolvers,hypre_maxiter,hypre_tol,.true.,hypre_solver_i,psolver_fft)
+#endif
   call setup_n_solvers(npsolvers,psolver_fft)
 #else
   call init_matrix_3d(cbcpre,bcpre,dl,.true.,is_bound,is_centered,lo,hi,periods, &

--- a/src/param.f90
+++ b/src/param.f90
@@ -12,14 +12,24 @@ real(rp), parameter, dimension(2,3) :: rkcoeff = reshape( [32._rp/60._rp,  0._rp
                                                            25._rp/60._rp, -17._rp/60._rp, &
                                                            45._rp/60._rp, -25._rp/60._rp], shape(rkcoeff))
 real(rp), parameter, dimension(3)   :: rkcoeff12 = rkcoeff(1,:)+rkcoeff(2,:)
-integer , parameter :: hypre_solver_i_default = 2
-real(rp), parameter :: hypre_tol_default      = real(1.e-4,rp)
-integer , parameter :: hypre_maxiter_default  = 50
+integer , parameter :: hypre_solver_i_default               = 2
+real(rp), parameter :: hypre_tol_default                    = real(1.e-4,rp)
+integer , parameter :: hypre_maxiter_default                = 50
+integer , parameter :: hypre_fft_zero_mode_solver_i_default = 0
+integer , parameter :: hypre_precond_i_default              = 1
+integer , parameter :: hypre_precond_maxiter_default        = 10
+integer , parameter :: hypre_gmres_k_dim_default            = 0
+integer , parameter :: hypre_pfmg_relax_type_default        = -1
+integer , parameter :: hypre_pfmg_num_pre_relax_default     = 1
+integer , parameter :: hypre_pfmg_num_post_relax_default    = 1
 integer , parameter :: max_blocks = 999
 logical , parameter :: is_cmpt_forces = .false.
 integer  :: hypre_solver_i
 real(rp) :: hypre_tol
 integer  :: hypre_maxiter
+integer  :: hypre_fft_zero_mode_solver_i
+integer  :: hypre_precond_i,hypre_precond_maxiter,hypre_gmres_k_dim
+integer  :: hypre_pfmg_relax_type,hypre_pfmg_num_pre_relax,hypre_pfmg_num_post_relax
 !
 ! parameters to be determined from the input file 'dns.nml'
 !
@@ -98,7 +108,10 @@ contains
                     ssource, &
                     is_sforced, &
                     scalf
-  namelist /hypre/ hypre_solver_i,hypre_tol,hypre_maxiter
+  namelist /hypre/ hypre_solver_i,hypre_tol,hypre_maxiter, &
+                   hypre_fft_zero_mode_solver_i, &
+                   hypre_precond_i,hypre_precond_maxiter,hypre_gmres_k_dim, &
+                   hypre_pfmg_relax_type,hypre_pfmg_num_pre_relax,hypre_pfmg_num_post_relax
   namelist /blocks/ nblocks, &
                     block_dims,block_ng,block_lmin,block_lmax,block_gt,block_gr, &
                     block_cbcvel,block_cbcpre,block_bcvel,block_bcpre, &
@@ -114,9 +127,16 @@ contains
   nscal = 0
   beta = 0._rp
   alpha_max = 0._rp
-  hypre_solver_i = hypre_solver_i_default
-  hypre_tol      = hypre_tol_default
-  hypre_maxiter  = hypre_maxiter_default
+  hypre_solver_i               = hypre_solver_i_default
+  hypre_tol                    = hypre_tol_default
+  hypre_maxiter                = hypre_maxiter_default
+  hypre_fft_zero_mode_solver_i = hypre_fft_zero_mode_solver_i_default
+  hypre_precond_i              = hypre_precond_i_default
+  hypre_precond_maxiter        = hypre_precond_maxiter_default
+  hypre_gmres_k_dim            = hypre_gmres_k_dim_default
+  hypre_pfmg_relax_type        = hypre_pfmg_relax_type_default
+  hypre_pfmg_num_pre_relax     = hypre_pfmg_num_pre_relax_default
+  hypre_pfmg_num_post_relax    = hypre_pfmg_num_post_relax_default
   block_dims(:,:) = 1
   block_ng(:,:) = 1
   block_lmin(:,:) = 0._rp
@@ -251,10 +271,15 @@ contains
   !
   ! validate iterative solver parameters
   !
-  if(hypre_solver_i < 1 .or. hypre_solver_i > 4) then
-    if(myid == 0) write(stderr,*) '*** Error: invalid solver choice [1-4] *** '
+  if(hypre_solver_i < 1 .or. hypre_solver_i > 5) then
+    if(myid == 0) write(stderr,*) '*** Error: invalid solver choice [1-5] *** '
     if(myid == 0) write(stderr,*) 'Reverting to the default (2 -> PFMG)...'
     hypre_solver_i = hypre_solver_i_default
+  end if
+  if(hypre_fft_zero_mode_solver_i < 0 .or. hypre_fft_zero_mode_solver_i > 5) then
+    if(myid == 0) write(stderr,*) '*** Error: invalid FFT zero-mode solver choice [0-5] *** '
+    if(myid == 0) write(stderr,*) 'Reverting to the default (0 -> same solver)...'
+    hypre_fft_zero_mode_solver_i = hypre_fft_zero_mode_solver_i_default
   end if
   if(hypre_tol > 1._rp .or. hypre_tol < 0._rp) then
     if(myid == 0) write(stderr,*) '*** Error: iterative error tolerance is too high or negative *** '
@@ -265,6 +290,36 @@ contains
     if(myid == 0) write(stderr,*) '*** Error: maximum number of iterations needs to be > 0 *** '
     if(myid == 0) write(stderr,*) 'Reverting to the default (50)...'
     hypre_maxiter = hypre_maxiter_default
+  end if
+  if(.not.any(hypre_precond_i == [0,1,9])) then
+    if(myid == 0) write(stderr,*) '*** Error: invalid Krylov preconditioner choice [0, 1, or 9] *** '
+    if(myid == 0) write(stderr,*) 'Reverting to the default (1 -> PFMG)...'
+    hypre_precond_i = hypre_precond_i_default
+  end if
+  if(hypre_precond_maxiter < 1) then
+    if(myid == 0) write(stderr,*) '*** Error: preconditioner iterations need to be > 0 *** '
+    if(myid == 0) write(stderr,*) 'Reverting to the default (10)...'
+    hypre_precond_maxiter = hypre_precond_maxiter_default
+  end if
+  if(hypre_gmres_k_dim < 0) then
+    if(myid == 0) write(stderr,*) '*** Error: GMRES k_dim cannot be negative *** '
+    if(myid == 0) write(stderr,*) 'Reverting to the default (0 -> HYPRE default)...'
+    hypre_gmres_k_dim = hypre_gmres_k_dim_default
+  end if
+  if(hypre_pfmg_relax_type < -1 .or. hypre_pfmg_relax_type > 3) then
+    if(myid == 0) write(stderr,*) '*** Error: invalid PFMG relaxation type [-1, 0-3] *** '
+    if(myid == 0) write(stderr,*) 'Reverting to the default (-1 -> automatic)...'
+    hypre_pfmg_relax_type = hypre_pfmg_relax_type_default
+  end if
+  if(hypre_pfmg_num_pre_relax < 0) then
+    if(myid == 0) write(stderr,*) '*** Error: PFMG pre-relaxation count cannot be negative *** '
+    if(myid == 0) write(stderr,*) 'Reverting to the default (1)...'
+    hypre_pfmg_num_pre_relax = hypre_pfmg_num_pre_relax_default
+  end if
+  if(hypre_pfmg_num_post_relax < 0) then
+    if(myid == 0) write(stderr,*) '*** Error: PFMG post-relaxation count cannot be negative *** '
+    if(myid == 0) write(stderr,*) 'Reverting to the default (1)...'
+    hypre_pfmg_num_post_relax = hypre_pfmg_num_post_relax_default
   end if
   contains
     subroutine abort_input(fname,msg)

--- a/src/solver.f90
+++ b/src/solver.f90
@@ -2,14 +2,15 @@ module mod_solver
   use mpi_f08
   use mod_common_mpi, only: ierr
   use mod_types
-  use, intrinsic :: iso_c_binding, only: C_PTR
+  use, intrinsic :: iso_c_binding, only: C_PTR,C_NULL_PTR
   implicit none
   private
   public init_bc_rhs,init_matrix_3d,create_solver,setup_solver, &
          add_constant_to_diagonal,add_weighted_constant_to_diagonal, &
          solve_helmholtz,finalize_matrix,finalize_solver, &
-         hypre_solver, add_constant_to_boundary, &
-         HYPRESolverSMG,HYPRESolverPFMG,HYPRESolverGMRES,HYPRESolverBiCGSTAB
+         hypre_solver,configure_hypre_options,add_constant_to_boundary, &
+         HYPRESolverSMG,HYPRESolverPFMG,HYPRESolverGMRES,HYPRESolverBiCGSTAB, &
+         HYPRESolverFlexGMRES
 #if defined(_FFT_X) || defined(_FFT_Y) || defined(_FFT_Z)
   public init_fft_reduction,init_n_2d_matrices,create_n_solvers,setup_n_solvers, &
          add_constant_to_n_diagonals,add_weighted_constant_to_n_diagonals, &
@@ -31,16 +32,56 @@ module mod_solver
 !    integer           , dimension(n) :: disps
 !    type(MPI_DATATYPE), dimension(n) :: types
 !  end type alltoallw
-  integer, parameter :: HYPRESolverSMG      = 1, &
-                        HYPRESolverPFMG     = 2, &
-                        HYPRESolverGMRES    = 3, &
-                        HYPRESolverBiCGSTAB = 4
+  integer, parameter :: HYPRESolverSMG       = 1, &
+                        HYPRESolverPFMG      = 2, &
+                        HYPRESolverGMRES     = 3, &
+                        HYPRESolverBiCGSTAB  = 4, &
+                        HYPRESolverFlexGMRES = 5
   logical, parameter :: is_leverage_symmetric_operators = .true.
+  integer, save :: hypre_precond_i_cfg           = 1,  &
+                   hypre_precond_maxiter_cfg     = 10, &
+                   hypre_gmres_k_dim_cfg         = 0,  &
+                   hypre_pfmg_relax_type_cfg     = -1, &
+                   hypre_pfmg_num_pre_relax_cfg  = 1,  &
+                   hypre_pfmg_num_post_relax_cfg = 1
   type hypre_solver
     type(C_PTR) :: grid,stencil,precond,solver,mat,rhs,sol
-    integer     :: stype,comm_hypre
+    integer     :: stype,ptype,comm_hypre
   end type hypre_solver
   contains
+  subroutine configure_hypre_options(precond_i,precond_maxiter,gmres_k_dim, &
+                                     pfmg_relax_type,pfmg_num_pre_relax,pfmg_num_post_relax)
+    implicit none
+    integer, intent(in) :: precond_i,precond_maxiter,gmres_k_dim, &
+                           pfmg_relax_type,pfmg_num_pre_relax,pfmg_num_post_relax
+    hypre_precond_i_cfg            = precond_i
+    hypre_precond_maxiter_cfg      = precond_maxiter
+    hypre_gmres_k_dim_cfg          = gmres_k_dim
+    hypre_pfmg_relax_type_cfg      = pfmg_relax_type
+    hypre_pfmg_num_pre_relax_cfg   = pfmg_num_pre_relax
+    hypre_pfmg_num_post_relax_cfg  = pfmg_num_post_relax
+  end subroutine configure_hypre_options
+
+  subroutine configure_pfmg(solver,maxiter,maxerror,is_symm_matrix)
+    implicit none
+    type(C_PTR), intent(in) :: solver
+    integer    , intent(in) :: maxiter
+    real(rp)   , intent(in) :: maxerror
+    logical    , intent(in) :: is_symm_matrix
+    integer :: relax_type
+    call HYPRE_StructPFMGSetMaxIter(solver,maxiter,ierr)
+    call HYPRE_StructPFMGSetTol(solver,maxerror,ierr)
+    call HYPRE_StructPFMGSetRelChange(solver,1,ierr)
+    relax_type = hypre_pfmg_relax_type_cfg
+    if(relax_type < 0) then
+      relax_type = 1
+      if(is_leverage_symmetric_operators.and.is_symm_matrix) relax_type = 2
+    end if
+    call HYPRE_StructPFMGSetRelaxType(solver,relax_type,ierr)
+    call HYPRE_StructPFMGSetNumPreRelax(solver,hypre_pfmg_num_pre_relax_cfg,ierr)
+    call HYPRE_StructPFMGSetNumPostRelax(solver,hypre_pfmg_num_post_relax_cfg,ierr)
+  end subroutine configure_pfmg
+
   subroutine init_bc_rhs(cbc,bc,dl,is_bound,is_centered,lo,hi,periods, &
                          dx1,dx2,dy1,dy2,dz1,dz2,rhsx,rhsy,rhsz,bcx,bcy,bcz)
     !
@@ -386,6 +427,8 @@ module mod_solver
     !       freely available under a GPL license
     !       http://www.ida.upmc.fr/~zaleski/paris
     !
+    precond = C_NULL_PTR
+    precond_id = 9
     if      ( stype == HYPRESolverSMG ) then
       call HYPRE_StructSMGCreate(asolver%comm_hypre,solver,ierr)
       call HYPRE_StructSMGSetMaxIter(solver,maxiter,ierr)
@@ -396,31 +439,20 @@ module mod_solver
 #endif
     else if ( stype == HYPRESolverPFMG ) then
       call HYPRE_StructPFMGCreate(asolver%comm_hypre,solver,ierr)
-      call HYPRE_StructPFMGSetMaxIter(solver,maxiter,ierr)
-      call HYPRE_StructPFMGSetTol(solver,maxerror,ierr)
+      call configure_pfmg(solver,maxiter,maxerror,is_symm_matrix)
 #ifdef _HYPRE_LOG
       call HYPRE_structPFMGsetLogging(solver,1,ierr)
       call HYPRE_StructPFMGSetPrintLevel(solver,1,ierr)
 #endif
-      call HYPRE_StructPFMGSetRelChange(solver,1,ierr)
-      ! Relaxiation Method: 2 is the fastest if symm matrix
-      ! 0: Jacobi
-      ! 1: Weighted Jacobi (default)
-      ! 2: Red/Black Gauss-Seidel (symmetric: RB pre- and post-relaxation)
-      ! 3: Red/Black Gauss-Seidel (nonsymmetric: RB pre- and post-relaxation)
-      if(.not.(is_leverage_symmetric_operators.and.is_symm_matrix)) then
-        call HYPRE_StructPFMGSetRelaxType(solver,1,ierr)
-      else
-        call HYPRE_StructPFMGSetRelaxType(solver,2,ierr)
-      end if
-      call HYPRE_StructPFMGSetNumPreRelax(solver,1,ierr)
-      call HYPRE_StructPFMGSetNumPostRelax(solver,1,ierr)
     else if ( stype == HYPRESolverGMRES .or. &
-              stype == HYPRESolverBiCGSTAB   ) then
+              stype == HYPRESolverBiCGSTAB .or. &
+              stype == HYPRESolverFlexGMRES ) then
       if      ( stype == HYPRESolverGMRES ) then
         call HYPRE_StructGMRESCreate(asolver%comm_hypre,solver,ierr)
         call HYPRE_StructGMRESSetMaxIter(solver,maxiter,ierr)
         call HYPRE_StructGMRESSetTol(solver,maxerror,ierr)
+        if(hypre_gmres_k_dim_cfg > 0) &
+          call HYPRE_StructGMRESSetKDim(solver,hypre_gmres_k_dim_cfg,ierr)
 #ifdef _HYPRE_LOG
         call HYPRE_StructGMRESSetLogging(solver,1,ierr)
 #endif
@@ -428,28 +460,39 @@ module mod_solver
         call HYPRE_StructBiCGSTABCreate(asolver%comm_hypre,solver,ierr)
         call HYPRE_StructBiCGSTABSetMaxIter(solver,maxiter,ierr)
         call HYPRE_StructBiCGSTABSetTol(solver,maxerror,ierr)
+      else if ( stype == HYPRESolverFlexGMRES ) then
+        call HYPRE_StructFGMRESCreate(asolver%comm_hypre,solver,ierr)
+        call HYPRE_StructFGMRESSetMaxIter(solver,maxiter,ierr)
+        call HYPRE_StructFGMRESSetTol(solver,maxerror,ierr)
+        if(hypre_gmres_k_dim_cfg > 0) &
+          call HYPRE_StructFGMRESSetKDim(solver,hypre_gmres_k_dim_cfg,ierr)
+#ifdef _HYPRE_LOG
+        call HYPRE_StructFGMRESSetLogging(solver,1,ierr)
+#endif
       end if
-      ! Use PFMG as preconditioner
-      call HYPRE_StructPFMGCreate(asolver%comm_hypre,precond,ierr)
-      call HYPRE_StructPFMGSetMaxIter(precond,10,ierr)
-      call HYPRE_StructPFMGSetTol(precond,0._rp,ierr)
-      call HYPRE_StructPFMGSetZeroGuess(precond,ierr)
-      call HYPRE_StructPFMGSetRelChange(precond,1,ierr)
-      if(.not.(is_leverage_symmetric_operators.and.is_symm_matrix)) then
-        call HYPRE_StructPFMGSetRelaxType(precond,1,ierr)
-      else
-        call HYPRE_StructPFMGSetRelaxType(precond,2,ierr)
+      precond_id = hypre_precond_i_cfg
+      if(precond_id == 0) then
+        call HYPRE_StructSMGCreate(asolver%comm_hypre,precond,ierr)
+        call HYPRE_StructSMGSetMaxIter(precond,hypre_precond_maxiter_cfg,ierr)
+        call HYPRE_StructSMGSetTol(precond,0._rp,ierr)
+        call HYPRE_StructSMGSetZeroGuess(precond,ierr)
+      else if(precond_id == 1) then
+        call HYPRE_StructPFMGCreate(asolver%comm_hypre,precond,ierr)
+        call configure_pfmg(precond,hypre_precond_maxiter_cfg,0._rp,is_symm_matrix)
+        call HYPRE_StructPFMGSetZeroGuess(precond,ierr)
       end if
-      precond_id = 1   ! Set PFMG as preconditioner
       if      ( stype == HYPRESolverGMRES ) then
         call HYPRE_StructGMRESSetPrecond(solver,precond_id,precond,ierr)
       else if ( stype == HYPRESolverBiCGSTAB ) then
         call HYPRE_StructBiCGSTABSetPrecond(solver,precond_id,precond,ierr)
+      else if ( stype == HYPRESolverFlexGMRES ) then
+        call HYPRE_StructFGMRESSetPrecond(solver,precond_id,precond,ierr)
       end if
-      asolver%precond = precond
     end if
+    asolver%precond = precond
     asolver%solver  = solver
     asolver%stype   = stype
+    asolver%ptype   = precond_id
   end subroutine create_solver
   subroutine setup_solver(asolver)
     implicit none
@@ -474,11 +517,14 @@ module mod_solver
     else if ( stype == HYPRESolverPFMG ) then
       call HYPRE_StructPFMGSetup(solver,mat,rhs,sol,ierr)
     else if ( stype == HYPRESolverGMRES .or. &
-             stype == HYPRESolverBiCGSTAB   ) then
+              stype == HYPRESolverBiCGSTAB .or. &
+              stype == HYPRESolverFlexGMRES ) then
       if      ( stype == HYPRESolverGMRES ) then
         call HYPRE_StructGMRESSetup(solver,mat,rhs,sol,ierr)
       else if ( stype == HYPRESolverBiCGSTAB ) then
         call HYPRE_StructBiCGSTABSetup(solver,mat,rhs,sol,ierr)
+      else if ( stype == HYPRESolverFlexGMRES ) then
+        call HYPRE_StructFGMRESSetup(solver,mat,rhs,sol,ierr)
       end if
     end if
   end subroutine setup_solver
@@ -560,6 +606,8 @@ module mod_solver
     else if ( stype == HYPRESolverBiCGSTAB ) then
       call HYPRE_StructBiCGSTABSolve(solver,mat,rhs,sol,ierr)
       !call HYPRE_StructBiCGSTABGetNumItera(solver, num_iterations,ierr)
+    else if ( stype == HYPRESolverFlexGMRES ) then
+      call HYPRE_StructFGMRESSolve(solver,mat,rhs,sol,ierr)
     end if ! stype
     !
     ! end of part based on the Paris Simulator code
@@ -575,11 +623,12 @@ module mod_solver
     implicit none
     type(hypre_solver), target, intent(in) :: asolver
     type(C_PTR), pointer :: precond,solver
-    integer    , pointer :: stype
+    integer    , pointer :: stype,ptype
     !
     precond => asolver%precond
     solver  => asolver%solver
     stype   => asolver%stype
+    ptype   => asolver%ptype
     !
     ! note: this part was based on the the Paris Simulator code
     !       freely available under a GPL license; see:
@@ -591,10 +640,15 @@ module mod_solver
       call HYPRE_StructPFMGDestroy(solver,ierr)
     else if ( stype == HYPRESolverGMRES ) then
       call HYPRE_StructGMRESDestroy(solver,ierr)
-      call HYPRE_StructPFMGDestroy(precond,ierr)
     else if ( stype == HYPRESolverBiCGSTAB ) then
       call HYPRE_StructBiCGSTABDestroy(solver,ierr)
-      call HYPRE_StructPFMGDestroy(precond,ierr)
+    else if ( stype == HYPRESolverFlexGMRES ) then
+      call HYPRE_StructFGMRESDestroy(solver,ierr)
+    end if
+    if(stype == HYPRESolverGMRES .or. stype == HYPRESolverBiCGSTAB .or. &
+       stype == HYPRESolverFlexGMRES) then
+      if(ptype == 0) call HYPRE_StructSMGDestroy(precond,ierr)
+      if(ptype == 1) call HYPRE_StructPFMGDestroy(precond,ierr)
     end if
   end subroutine finalize_solver
   subroutine finalize_matrix(asolver)
@@ -896,6 +950,8 @@ module mod_solver
       else if ( stype == HYPRESolverBiCGSTAB ) then
         call HYPRE_StructBiCGSTABSolve(solver,mat,rhs,sol,ierr)
         !call HYPRE_StructBiCGSTABGetNumItera(solver, num_iterations,ierr)
+      else if ( stype == HYPRESolverFlexGMRES ) then
+        call HYPRE_StructFGMRESSolve(solver,mat,rhs,sol,ierr)
       end if ! stype
       !
       ! end of part based on the Paris Simulator code
@@ -966,6 +1022,8 @@ module mod_solver
       else if ( stype == HYPRESolverBiCGSTAB ) then
         call HYPRE_StructBiCGSTABSolve(solver,mat,rhs,sol,ierr)
         !call HYPRE_StructBiCGSTABGetNumItera(solver, num_iterations,ierr)
+      else if ( stype == HYPRESolverFlexGMRES ) then
+        call HYPRE_StructFGMRESSolve(solver,mat,rhs,sol,ierr)
       end if ! stype
       !
       ! end of part based on the Paris Simulator code
@@ -1055,16 +1113,28 @@ module mod_solver
       asolver(q) = asolver_aux
     end do
   end subroutine init_n_3d_matrices
-  subroutine create_n_solvers(n,maxiter,maxerror,is_symm_matrix,stype,asolver)
+  subroutine create_n_solvers(n,maxiter,maxerror,is_symm_matrix,stype,asolver,lambda,zero_mode_stype)
     integer           , intent(   in) :: n
     integer           , intent(   in) :: maxiter
     real(rp)          , intent(   in) :: maxerror
     logical           , intent(   in) :: is_symm_matrix
     integer           , intent(   in) :: stype
     type(hypre_solver), intent(inout), dimension(:) :: asolver
-    integer :: q
+    real(rp)          , intent(   in), optional, dimension(:) :: lambda
+    integer           , intent(   in), optional :: zero_mode_stype
+    integer :: q,stype_q
+    real(rp) :: lambda_scale,lambda_tol
+    lambda_scale = 1._rp
+    if(present(lambda)) lambda_scale = max(lambda_scale,maxval(abs(lambda)))
+    lambda_tol = 100._rp*epsilon(lambda_scale)*lambda_scale
     do q=1,n
-      call create_solver(maxiter,maxerror,is_symm_matrix,stype,asolver(q))
+      stype_q = stype
+      if(present(lambda).and.present(zero_mode_stype)) then
+        if(q <= size(lambda).and.zero_mode_stype > 0) then
+          if(abs(lambda(q)) <= lambda_tol) stype_q = zero_mode_stype
+        end if
+      end if
+      call create_solver(maxiter,maxerror,is_symm_matrix,stype_q,asolver(q))
     end do
   end subroutine create_n_solvers
   subroutine setup_n_solvers(n,asolver)
@@ -1215,6 +1285,8 @@ module mod_solver
       else if ( stype == HYPRESolverBiCGSTAB ) then
         call HYPRE_StructBiCGSTABSolve(solver,mat,rhs,sol,ierr)
         !call HYPRE_StructBiCGSTABGetNumItera(solver, num_iterations,ierr)
+      else if ( stype == HYPRESolverFlexGMRES ) then
+        call HYPRE_StructFGMRESSolve(solver,mat,rhs,sol,ierr)
       end if ! stype
       !
       ! end of part based on the Paris Simulator code

--- a/tests/hypre_solver_options/blocks.nml
+++ b/tests/hypre_solver_options/blocks.nml
@@ -1,0 +1,19 @@
+&blocks
+nblocks = 1
+block_dims(1:3,1) = 1, 1, 1
+block_ng(1:3,1) = 16, 16, 16
+block_lmin(1:3,1) = 0., 0., 0.
+block_lmax(1:3,1) = 1., 1., 1.
+block_gt(1:3,1) = 0, 0, 0
+block_gr(1:3,1) = 0., 0., 0.
+block_cbcvel(0:1,1:3,1,1) = 'F', 'F', 'F', 'F', 'F', 'F'
+block_cbcvel(0:1,1:3,2,1) = 'F', 'F', 'F', 'F', 'F', 'F'
+block_cbcvel(0:1,1:3,3,1) = 'F', 'F', 'F', 'F', 'F', 'F'
+block_cbcpre(0:1,1:3,1) = 'F', 'F', 'F', 'F', 'F', 'F'
+block_bcvel(0:1,1:3,1,1) = 1., 1., 1., 1., 1., 1.
+block_bcvel(0:1,1:3,2,1) = 1., 1., 1., 1., 1., 1.
+block_bcvel(0:1,1:3,3,1) = 1., 1., 1., 1., 1., 1.
+block_bcpre(0:1,1:3,1) = 1., 1., 1., 1., 1., 1.
+block_inflow_type(0:1,1:3,1) = 0, 0, 0, 0, 0, 0
+block_inivel(1) = 'tgv'
+/

--- a/tests/hypre_solver_options/blocks_slab.nml
+++ b/tests/hypre_solver_options/blocks_slab.nml
@@ -1,0 +1,19 @@
+&blocks
+nblocks = 1
+block_dims(1:3,1) = 1, 2, 1
+block_ng(1:3,1) = 16, 16, 16
+block_lmin(1:3,1) = 0., 0., 0.
+block_lmax(1:3,1) = 1., 1., 1.
+block_gt(1:3,1) = 0, 0, 0
+block_gr(1:3,1) = 0., 0., 0.
+block_cbcvel(0:1,1:3,1,1) = 'F', 'F', 'F', 'F', 'F', 'F'
+block_cbcvel(0:1,1:3,2,1) = 'F', 'F', 'F', 'F', 'F', 'F'
+block_cbcvel(0:1,1:3,3,1) = 'F', 'F', 'F', 'F', 'F', 'F'
+block_cbcpre(0:1,1:3,1) = 'F', 'F', 'F', 'F', 'F', 'F'
+block_bcvel(0:1,1:3,1,1) = 1., 1., 1., 1., 1., 1.
+block_bcvel(0:1,1:3,2,1) = 1., 1., 1., 1., 1., 1.
+block_bcvel(0:1,1:3,3,1) = 1., 1., 1., 1., 1., 1.
+block_bcpre(0:1,1:3,1) = 1., 1., 1., 1., 1., 1.
+block_inflow_type(0:1,1:3,1) = 0, 0, 0, 0, 0, 0
+block_inivel(1) = 'tgv'
+/

--- a/tests/hypre_solver_options/dns_bicgstab_pfmg.nml
+++ b/tests/hypre_solver_options/dns_bicgstab_pfmg.nml
@@ -1,0 +1,16 @@
+&dns
+cfl = .95, dtmax = 1.e9, dt_f = 1.e-3
+visci = 100.
+nstep = 3, time_max = 100., tw_max = 0.1
+stop_type(1:3) = T, F, F
+restart = F, is_overwrite_save = T, nsaves_max = 0
+icheck = 1, iout0d = 0, iout1d = 0, iout2d = 0, iout3d = 0, isave = 0
+bforce(1:3) = 0., 0., 0.
+/
+
+&hypre
+hypre_solver_i = 4, hypre_tol = 1.e-8, hypre_maxiter = 200
+hypre_precond_i = 1, hypre_precond_maxiter = 1
+hypre_pfmg_relax_type = 3
+hypre_pfmg_num_pre_relax = 0, hypre_pfmg_num_post_relax = 4
+/

--- a/tests/hypre_solver_options/dns_fft_hybrid.nml
+++ b/tests/hypre_solver_options/dns_fft_hybrid.nml
@@ -1,0 +1,17 @@
+&dns
+cfl = .95, dtmax = 1.e9, dt_f = 1.e-3
+visci = 100.
+nstep = 3, time_max = 100., tw_max = 0.1
+stop_type(1:3) = T, F, F
+restart = F, is_overwrite_save = T, nsaves_max = 0
+icheck = 1, iout0d = 0, iout1d = 0, iout2d = 0, iout3d = 0, isave = 0
+bforce(1:3) = 0., 0., 0.
+/
+
+&hypre
+hypre_solver_i = 4, hypre_fft_zero_mode_solver_i = 2
+hypre_tol = 1.e-8, hypre_maxiter = 200
+hypre_precond_i = 1, hypre_precond_maxiter = 1
+hypre_pfmg_relax_type = 3
+hypre_pfmg_num_pre_relax = 0, hypre_pfmg_num_post_relax = 4
+/

--- a/tests/hypre_solver_options/dns_flexgmres_pfmg.nml
+++ b/tests/hypre_solver_options/dns_flexgmres_pfmg.nml
@@ -1,0 +1,17 @@
+&dns
+cfl = .95, dtmax = 1.e9, dt_f = 1.e-3
+visci = 100.
+nstep = 3, time_max = 100., tw_max = 0.1
+stop_type(1:3) = T, F, F
+restart = F, is_overwrite_save = T, nsaves_max = 0
+icheck = 1, iout0d = 0, iout1d = 0, iout2d = 0, iout3d = 0, isave = 0
+bforce(1:3) = 0., 0., 0.
+/
+
+&hypre
+hypre_solver_i = 5, hypre_tol = 1.e-8, hypre_maxiter = 200
+hypre_precond_i = 1, hypre_precond_maxiter = 1
+hypre_gmres_k_dim = 20
+hypre_pfmg_relax_type = 3
+hypre_pfmg_num_pre_relax = 0, hypre_pfmg_num_post_relax = 4
+/

--- a/tests/hypre_solver_options/dns_flexgmres_smg.nml
+++ b/tests/hypre_solver_options/dns_flexgmres_smg.nml
@@ -1,0 +1,15 @@
+&dns
+cfl = .95, dtmax = 1.e9, dt_f = 1.e-3
+visci = 100.
+nstep = 3, time_max = 100., tw_max = 0.1
+stop_type(1:3) = T, F, F
+restart = F, is_overwrite_save = T, nsaves_max = 0
+icheck = 1, iout0d = 0, iout1d = 0, iout2d = 0, iout3d = 0, isave = 0
+bforce(1:3) = 0., 0., 0.
+/
+
+&hypre
+hypre_solver_i = 5, hypre_tol = 1.e-8, hypre_maxiter = 200
+hypre_precond_i = 0, hypre_precond_maxiter = 1
+hypre_gmres_k_dim = 20
+/

--- a/tests/hypre_solver_options/dns_gmres_none.nml
+++ b/tests/hypre_solver_options/dns_gmres_none.nml
@@ -1,0 +1,15 @@
+&dns
+cfl = .95, dtmax = 1.e9, dt_f = 1.e-3
+visci = 100.
+nstep = 3, time_max = 100., tw_max = 0.1
+stop_type(1:3) = T, F, F
+restart = F, is_overwrite_save = T, nsaves_max = 0
+icheck = 1, iout0d = 0, iout1d = 0, iout2d = 0, iout3d = 0, isave = 0
+bforce(1:3) = 0., 0., 0.
+/
+
+&hypre
+hypre_solver_i = 3, hypre_tol = 1.e-8, hypre_maxiter = 500
+hypre_precond_i = 9
+hypre_gmres_k_dim = 20
+/

--- a/tests/hypre_solver_options/test.py
+++ b/tests/hypre_solver_options/test.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+import math
+import re
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    log = Path(sys.argv[1]).read_text()
+    values = [
+        float(value)
+        for value in re.findall(r"Maximum divergence\s*=\s*([+\-0-9.Ee]+)", log)
+    ]
+    assert len(values) == 3, f"expected three divergence checks, found {len(values)}"
+    assert all(math.isfinite(value) for value in values), values
+    assert max(values) < 1.0e-5, values
+    assert "Aborting" not in log
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/hypre_solver_options/testit.sh
+++ b/tests/hypre_solver_options/testit.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+set -e
+
+TESTDIR=$(pwd)
+SNACDIR=$(pwd)/../..
+RUNDIR=$SNACDIR/run
+EXEC=snac
+MPIRUN_OPTIONS='--oversubscribe'
+if mpirun --version 2>&1 | grep -qi intel; then MPIRUN_OPTIONS=""; fi
+
+run_case() {
+  DNS_FILE=$1
+  CASE_NAME=$2
+  BLOCKS_FILE=${3:-blocks.nml}
+  NP=${4:-1}
+  cp "$TESTDIR/$DNS_FILE" "$RUNDIR/dns.nml"
+  cp "$TESTDIR/$BLOCKS_FILE" "$RUNDIR/blocks.nml"
+  rm -rf "$RUNDIR/data"
+  mkdir -p "$RUNDIR/data"
+  cd "$RUNDIR"
+  set +e
+  mpirun -n "$NP" $MPIRUN_OPTIONS ./${EXEC} > "$CASE_NAME.log" 2> "$CASE_NAME.err"
+  status=$?
+  set -e
+  if [ -s "$CASE_NAME.err" ]; then
+    cat "$CASE_NAME.err"
+    exit 1
+  fi
+  if [ $status -ne 0 ]; then
+    exit $status
+  fi
+  python "$TESTDIR/test.py" "$CASE_NAME.log"
+  cd "$TESTDIR"
+}
+
+rm -rf "$RUNDIR"
+cd "$SNACDIR"
+make clean
+make FFT_AXIS=0 -j run
+run_case dns_bicgstab_pfmg.nml bicgstab_pfmg
+run_case dns_flexgmres_pfmg.nml flexgmres_pfmg
+run_case dns_flexgmres_smg.nml flexgmres_smg
+run_case dns_gmres_none.nml gmres_none
+
+cd "$SNACDIR"
+make clean
+make FFT_AXIS=1 -j run
+run_case dns_fft_hybrid.nml fft_hybrid
+
+cd "$SNACDIR"
+make clean
+make FFT_AXIS=1 FFT_USE_SLABS=1 -j run
+run_case dns_fft_hybrid.nml fft_hybrid_slab blocks_slab.nml 2
+
+rm -rf "$RUNDIR"


### PR DESCRIPTION
## Summary

This PR extends the HYPRE solver configuration available for the Poisson and Helmholtz equations.

It:

- adds FlexGMRES as an iterative solver;
- exposes the restart dimension (`k_dim`) for GMRES and FlexGMRES;
- allows SMG, PFMG, or no preconditioner for Krylov solvers;
- makes the number of preconditioner cycles configurable;
- exposes the PFMG relaxation type and numbers of pre- and post-relaxation sweeps;
- allows a separate solver for the zero Fourier mode in FFT-reduced pressure solves, enabling combinations such as stand-alone PFMG for the singular zero mode and BiCGSTAB+PFMG(1) for the shifted systems;
- documents the new `&hypre` namelist parameters.

Stand-alone PFMG remains the default, preserving the behaviour of existing input files.

## Testing

Added focused regression cases covering:

- BiCGSTAB+PFMG;
- FlexGMRES+PFMG;
- FlexGMRES+SMG;
- GMRES without a preconditioner;
- the FFT hybrid solver;
- the FFT slab path on two MPI ranks.

The existing lid-driven cavity, differentially heated cavity, and grid-generator tests also pass. Standard, FFT, slab-FFT, sliced-pencil, implicit-diffusion, and debug build configurations were checked.

Closes #55.